### PR TITLE
DTSPO-33272 Bump function chart dependency to 2.6.3 templates  from t…

### DIFF
--- a/charts/recipe-receiver/Chart.yaml
+++ b/charts/recipe-receiver/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: recipe-receiver
 description: A Helm chart to deploy the recipe receiver app.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.1.0"
 dependencies:
   - name: function
-    version: 2.6.2
+    version: 2.6.3
     repository: 'oci://hmctsprod.azurecr.io/helm'


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-33272

## What
Bump `function` chart dependency 2.6.2 → 2.6.3.

## Why
2.6.2 templates `rollout.propagationPolicy` from the wrong values key, always rendering "gradual" which KEDA's ScaledJob CRD rejects. Fixed in chart-function#56, released in 2.6.3. This was breaking toffee-recipe-receiver installs on the recreated ss-stg-00-aks cluster.
